### PR TITLE
Add contentcreated date-time field

### DIFF
--- a/content/ninjs/pa-list-ninjs-schema_1.3.json
+++ b/content/ninjs/pa-list-ninjs-schema_1.3.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://schema.pressassociation.io/content/ninjs/pa-list-ninjs-schema_1.3.json#",
+  "title": "PA List IPTC ninjs - News in JSON - version 1.3",
+  "description": "A list wrapper around the Press Association (PA) modification of IPTC's Ninjs Schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["total", "limit", "offset", "item"],
+  "properties": {
+    "total": {
+      "description": "The total number of news objects across all pages of the list.",
+      "type": "number"
+    },
+    "limit": {
+      "description": "The number of news objects to return in 1 page of the list.",
+      "type": "number"
+    },
+    "offset": {
+      "description": "The number of news objects to skip over before returning this page of the list.",
+      "type": "number"
+    },
+    "item": {
+      "description": "The new objects returned in this page of the list.",
+      "type": "array",
+      "items": { "$ref": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.3.json#" }
+    },
+    "events": {
+      "description": "Details of events referenced in the Item list.",
+      "type": "object",
+      "patternProperties": {
+        "*": {
+          "description": "An entry for an event. The key is the event's uri.",
+          "type": "object",
+          "patternProperties": {
+            "*": {
+              "description": "An entry for stats about a items linked to an event of a certain profile. The key is the value of the profile.",
+              "type": "object",
+              "patternProperties": {
+                "*": {
+                  "description": "An entry for stats about a items linked to an event of a certain type. The key is the value of the type.",
+                  "type": "object",
+                  "properties": {
+                		"total" : {
+                			"description" : "The total number of items linked to an event for the given profile & type.",
+                			"type" : "number"
+                		},
+                    "links": {
+                      "description": "HATEOAS style links related to the list of news object.",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "rel": {
+                          "description": "The relationship of the link to the list of news object.",
+                          "type": "string"
+                        },
+                        "href": {
+                          "description": "The URL for accessing the link.",
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "properties": {
+        "links": {
+          "description": "HATEOAS style links related to the list of news object.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rel": {
+              "description": "The relationship of the link to the list of news object.",
+              "type": "string"
+            },
+            "href": {
+              "description": "The URL for accessing the link.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    }
+  },
+  "links": {
+    "description": "HATEOAS style links related to the list of news object.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "rel": {
+        "description": "The relationship of the link to the list of news object.",
+        "type": "string"
+      },
+      "href": {
+        "description": "The URL for accessing the link.",
+        "type": "string",
+        "format": "uri"
+      }
+    }
+  }
+}

--- a/content/ninjs/pa-ninjs-schema_1.3.json
+++ b/content/ninjs/pa-ninjs-schema_1.3.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.3.json#",
   "type": "object",
-  "title": "PA IPTC ninjs - News in JSON - version 1.1 (Derived from IPTC - News in JSON - version 1.1)",
+  "title": "PA IPTC ninjs - News in JSON - version 1.3 (Derived from IPTC - News in JSON - version 1.1)",
   "description": "A Press Association (PA) modification to the news item as JSON object -- copyright 2014 IPTC - International Press Telecommunications Council - www.iptc.org - Original document is published under the Creative Commons Attribution 3.0 license, see  http://creativecommons.org/licenses/by/3.0/  $$comment: as of 2014-03-13 ",
   "additionalProperties": false,
   "required": ["uri"],
@@ -401,7 +401,7 @@
       "additionalProperties": false,
       "patternProperties": {
         "^[a-zA-Z0-9]+": {
-          "$ref": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.1.json#"
+          "$ref": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.3.json#"
         }
       }
     },

--- a/content/ninjs/pa-ninjs-schema_1.3.json
+++ b/content/ninjs/pa-ninjs-schema_1.3.json
@@ -1,0 +1,425 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.3.json#",
+  "type": "object",
+  "title": "PA IPTC ninjs - News in JSON - version 1.1 (Derived from IPTC - News in JSON - version 1.1)",
+  "description": "A Press Association (PA) modification to the news item as JSON object -- copyright 2014 IPTC - International Press Telecommunications Council - www.iptc.org - Original document is published under the Creative Commons Attribution 3.0 license, see  http://creativecommons.org/licenses/by/3.0/  $$comment: as of 2014-03-13 ",
+  "additionalProperties": false,
+  "required": ["uri"],
+  "patternProperties": {
+    "^description_[a-zA-Z0-9_]+": {
+      "description": "A free-form textual description of the content of the item. (The string appended to description_ in the property name should reflect the format of the text)",
+      "type": "string"
+    },
+    "^body_[a-zA-Z0-9_]+": {
+      "description": "The textual content of the news object. (The string appended to body_ in the property name should reflect the format of the text)",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "uri": {
+      "description": "The identifier for this news object",
+      "type": "string"
+    },
+    "type": {
+      "description": "The generic news type of this news object",
+      "type": "string",
+      "enum": ["text", "audio", "video", "picture", "graphic", "composite", "social", "quiz", "big-number", "fact-box", "quote"]
+    },
+    "mimetype": {
+      "description": "A MIME type which applies to this news object",
+      "type": "string"
+    },
+    "representationtype": {
+      "description": "Indicates how complete this representation of a news item is",
+      "type": "string",
+      "enum": ["complete", "incomplete"]
+    },
+    "profile": {
+      "description": "An identifier for the kind of content of this news object",
+      "type": "string"
+    },
+    "version": {
+      "description": "The version of the news object which is identified by the uri property",
+      "type": "string"
+    },
+    "contentcreated": {
+      "description": "The date and time when the asset was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "versioncreated": {
+      "description": "The date and time when this version of the news object was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "firstcreated": {
+      "description": "The date and time when the first version of the news object was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "embargoed": {
+      "description": "The date and time before which all versions of the news object are embargoed. If absent, this object is not embargoed.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "pubstatus": {
+      "description": "The publishing status of the news object, its value is *usable* by default.",
+      "type": "string",
+      "enum": ["usable", "withheld", "canceled"]
+    },
+    "urgency": {
+      "description": "The editorial urgency of the content from 1 to 9. 1 represents the highest urgency, 9 the lowest.",
+      "type": "number"
+    },
+    "ranking": {
+      "description": "A value for comparing the importance of this news object compared to other news objects. 1 represents the highest ranking. Only postive integers are allowed.",
+      "type": "number"
+    },
+    "copyrightholder": {
+      "description": "The person or organisation claiming the intellectual property for the content.",
+      "type": "string"
+    },
+    "copyrightnotice": {
+      "description": "Any necessary copyright notice for claiming the intellectual property for the content.",
+      "type": "string"
+    },
+    "usageterms": {
+      "description": "A natural-language statement about the usage terms pertaining to the content.",
+      "type": "string"
+    },
+    "language": {
+      "description": "The human language used by the content. The value should follow IETF BCP47",
+      "type": "string"
+    },
+    "person": {
+      "description": "An individual human being",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of a person",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the person",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the person",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the person in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this person.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "organisation": {
+      "description": "An administrative and functional structure which may act as as a business, as a political party or not-for-profit party",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the organisation",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the organisation",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the organisation",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the organisation in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this organisation.",
+            "type": "string"
+          },
+          "symbols": {
+            "description": "Symbols used for a finanical instrument linked to the organisation at a specific market place",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ticker": {
+                  "description": "Ticker symbol used for the financial instrument",
+                  "type": "string"
+                },
+                "exchange": {
+                  "description": "Identifier for the marketplace which uses the ticker symbols of the ticker property",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "place": {
+      "description": "A named location",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^geometry_[a-zA-Z0-9_]+": {
+            "description": "An object holding geo data of this place. Could be of any relevant geo data JSON object definition.",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "name": {
+            "description": "The name of the place",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the place",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the place",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the place in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this place.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "subject": {
+      "description": "A concept with a relationship to the content",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the subject",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the subject",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the subject",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the subject in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this subject.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "event": {
+      "description": "Something which happens in a planned or unplanned manner",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the event",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the event",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the event",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the event in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this event.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "object": {
+      "description": "Something material, excluding persons",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the object",
+            "type": "string"
+          },
+          "rel": {
+            "description": "The relationship of the content of the news object to the object",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the object",
+            "type": "string",
+            "format": "uri"
+          },
+          "code": {
+            "description": "The code for the object in a scheme (= controlled vocabulary) which is identified by the scheme property",
+            "type": "string"
+          },
+          "profile": {
+            "description": "An identifier for the CV that defines this object.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "byline": {
+      "description": "The name(s) of the creator(s) of the content",
+      "type": "string"
+    },
+    "headline": {
+      "description": "A brief and snappy introduction to the content, designed to catch the reader's attention",
+      "type": "string"
+    },
+    "located": {
+      "description": "The name of the location from which the content originates.",
+      "type": "string"
+    },
+    "dates": {
+      "description": "All dates pertaining to the event (or the event of the item), in particular the start date and a duration or a set end date",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start"],
+      "properties": {
+        "start": {
+          "description": "The date and time the event commences.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "end": {
+          "description": "The date and time the event ends.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration": {
+          "description": "The period the event will last, expressed as a duration where the highest level is a day, e.g. P2D, PT10H, PT15M",
+          "type": "string",
+          "pattern": "P(?!$)(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+\\.)?(\\d+S)?)?"
+        }
+      }
+    },
+    "renditions": {
+      "description": "Wrapper for different renditions of non-textual content of the news object",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9]+": {
+          "description": "A specific rendition of a non-textual content of the news object.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "href": {
+              "description": "The URL for accessing the rendition as a resource",
+              "type": "string",
+              "format": "uri"
+            },
+            "mimetype": {
+              "description": "A MIME type which applies to the rendition",
+              "type": "string"
+            },
+            "title": {
+              "description": "A title for the link to the rendition resource",
+              "type": "string"
+            },
+            "height": {
+              "description": "For still and moving images: the height of the display area measured in pixels",
+              "type": "number"
+            },
+            "width": {
+              "description": "For still and moving images: the width of the display area measured in pixels",
+              "type": "number"
+            },
+            "sizeinbytes": {
+              "description": "The size of the rendition resource in bytes",
+              "type": "number"
+            },
+            "poi": {
+              "description": "The point of interest of the rendition.",
+              "type": "object",
+              "properties": {
+                "x": {
+                  "description": "The x co-ordinate of the point of interest.",
+                  "type": "number"
+                },
+                "y": {
+                  "description": "The y co-ordinate of the point of interest.",
+                  "type": "number"
+                }
+              }
+            },
+            "orientation": {
+              "type": "string",
+              "description": "The orientation of the rendition",
+              "enum": ["landscape", "portrait", "square"]
+            }
+          }
+        }
+      }
+    },
+    "associations": {
+      "description": "Content of news objects which are associated with this news object.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9]+": {
+          "$ref": "http://schema.pressassociation.io/content/ninjs/pa-ninjs-schema_1.1.json#"
+        }
+      }
+    },
+    "links": {
+      "description": "HATEOAS style links related to the news object.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rel": {
+          "description": "The relationship of the link to the news object.",
+          "type": "string"
+        },
+        "href": {
+          "description": "The URL for accessing the link.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will capture the date-time when the original asset was created
i.e. The time a photographer takes the photo according to the camera.

Added the following to the 1.2 schema:
```
+    "contentcreated": {
+      "description": "The date and time when the asset was created",
+      "type": "string",
+      "format": "date-time"
+    },
```

Implements: IAI-1316